### PR TITLE
BUG: update check_uid function to use uuid module

### DIFF
--- a/coss/interpolation.py
+++ b/coss/interpolation.py
@@ -77,8 +77,8 @@ class areal_interpolation:
 
         _check_crs_match(self.sources, self.targets)
 
-        sources, sid = _check_uid(self.sources, self.sid)
-        targets, tid = _check_uid(self.targets, self.tid)
+        sources, sid = _check_uid(self.sources, self.sid, uid_type="sources")
+        targets, tid = _check_uid(self.targets, self.tid, uid_type="targets")
 
         return sources.copy(), targets.copy(), sid, tid
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -1,6 +1,3 @@
-import numpy as np
-
-
 def _check_crs_match(sources, targets):
     """Check crs of GeoDataFrame match"""
 
@@ -20,12 +17,16 @@ def _check_crs_exists(gdf):
         raise KeyError("GeoDataFrame must contain a crs")
 
 
-def _check_uid(df, uid=None):
-    """Creates a unique identifier in GeoDataFrame is not specified"""
+def _check_uid(df, uid=None, uid_type="sources"):
+    """Creates a unique identifier for source or target GeoDataFrame"""
 
     if uid is None:
-        uid = df.name + "_uid"
-        df[uid] = np.arrange(len(df))
+        import uuid
+        if uid_type == "sources":
+            uid = "sid"
+        elif uid_type == "targets":
+            uid = "tid"
+        df[uid] = df.apply(lambda _: uuid.uuid4(), axis=1)
 
     return df, uid
 


### PR DESCRIPTION
As described in https://github.com/tastatham/coss/issues/2, An Error is thrown in the [_check_uid](https://github.com/tastatham/coss/blob/9271821260639aceacb9f5a6da1db3a0939bca45/coss/utils.py#L23) function , when GeoDataFrame.name does not exist.
.name is used to create a unique identifer when one does not exist or is not specified.
I have updated the _check_uid function to use the [uuid](https://docs.python.org/3/library/uuid.html) Python module.