### PR TITLE
ENH: Add st_make_grid function to create grids based on geopandas.GeoDataFrame total bounds 

### DIFF
--- a/coss/utils.py
+++ b/coss/utils.py
@@ -177,6 +177,31 @@ def _create_grid_geoms(coords, xres, yres):
     return box(xmins, ymins, xmaxs, ymaxs)
 
 
+def st_create_grid(gdf, res):
+    """Assumes projected coords e.g. res in metres"""
+
+    total_bounds = gdf.total_bounds
+
+    x, y = _grid_centroids(total_bounds, res)
+    coords = _cartesian_prod(x, y)
+    geoms = _create_grid_geoms(coords, res)
+    # convex hull / concave hull
+    grid = gpd.GeoDataFrame(geometry=geoms, crs=gdf.crs)
+
+    return grid
+
+
+def _grid_centroids(total_bounds, res):
+    """Calculate centroid for all grid cells"""
+
+    xmin, ymin, xmax, ymax = total_bounds
+
+    x = np.arange(start=(xmin + res), stop=xmax, step=res)
+    y = np.arange(start=(ymin + res), stop=ymax, step=res)
+
+    return x, y
+
+
 def _h3fy_updated(gdf, resolution):
     """
     h3_radius values calculated using;

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -223,6 +223,7 @@ def st_make_grid(
 
     if index:
         gdf, uid = _create_uid(gdf, uid_type="sources")
+        gdf = gdf.set_index("sources")
 
     return gdf
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -41,17 +41,26 @@ def _uid(df, uid=None, uid_type="sources"):
     return df, uid
 
 
-def _create_uid(df, uid_type="sources"):
-    """Creates a unique identifer"""
+def create_uid(df, uid):
+    """Create fast uid"""
     import random
     from fastuuid import UUID
+
+    df[uid] = [UUID(int=random.getrandbits(128), version=4) for x in range(len(df))]
+
+    return df
+
+
+def _create_uid(df, uid_type="sources"):
+    """Creates a unique identifer for areal interpolation methods"""
 
     if uid_type == "sources":
         uid = "sid"
     elif uid_type == "targets":
         uid = "tid"
 
-    df[uid] = [UUID(int=random.getrandbits(128), version=4) for x in range(len(df))]
+    df = create_uid(df, uid)
+
     return df, uid
 
 
@@ -163,6 +172,7 @@ def st_make_grid(
     crs=None,
     include_xy=True,
     index=True,
+    index_name="tid",
     dask=True,
 ):
 
@@ -184,6 +194,8 @@ def st_make_grid(
         whether to include x,y coords (mid point)
     index: bool
         whether to include a unique index
+    index_name: str
+        name of index
     dask: bool
         whether to use dask
 
@@ -222,8 +234,7 @@ def st_make_grid(
         gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
 
     if index:
-        gdf, uid = _create_uid(gdf, uid_type="sources")
-        gdf = gdf.set_index("sid")
+        gdf = create_uid(gdf, uid=index_name).set_index(index_name)
 
     return gdf
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -165,7 +165,7 @@ def rio2polygons(coords, rioxarray_obj):
 
 def _create_grid_geoms(coords, xres, yres):
 
-    """Create polygon grids based on x,y coords and x and y resolution"""
+    """Create polygon grids based on x,y projected coords and res"""
     from pygeos import box
 
     xmins = coords[:, 0] - (xres / 2)

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -139,26 +139,16 @@ def rio2gdf(
     else:
         raise ValueError(f"Only '{methods}' are supported")
 
-    if dask:
-        coords = coords.compute()
-        geoms = geoms.compute()
-
     if include_xy:
+        if dask:
+            coords = coords.compute()
+            geoms = geoms.compute()
         df = pd.DataFrame({"x": coords[:, 0], "y": coords[:, 1]})
         gdf = gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
     else:
+        if dask:
+            geoms = geoms.compute()
         gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
-
-    if index:
-        gdf, uid = _create_uid(gdf, uid_type="sources")
-
-    if dask:
-        df = pd.Series(vals.ravel(), name=name)
-        geoms = geoms.compute()
-    else:
-        df = pd.Series(vals.ravel(), name=name)
-
-    gdf = gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
 
     if index:
         gdf, uid = _create_uid(gdf, uid_type="sources")
@@ -220,14 +210,15 @@ def st_make_grid(
             "No crs or GeoDataFrame passed, so no crs is set for the resultant GeoDataFrame"
         )
 
-    if dask:
-        coords = coords.compute()
-        geoms = geoms.compute()
-
     if include_xy:
+        if dask:
+            coords = coords.compute()
+            geoms = geoms.compute()
         df = pd.DataFrame({"x": coords[:, 0], "y": coords[:, 1]})
         gdf = gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
     else:
+        if dask:
+            geoms = geoms.compute()
         gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
 
     if index:

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -177,7 +177,7 @@ def _create_grid_geoms(coords, xres, yres):
     return box(xmins, ymins, xmaxs, ymaxs)
 
 
-def st_create_grid(gdf, res):
+def st_make_grid(gdf, res):
     """Assumes projected coords e.g. res in metres"""
 
     total_bounds = gdf.total_bounds

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -223,7 +223,7 @@ def st_make_grid(
 
     if index:
         gdf, uid = _create_uid(gdf, uid_type="sources")
-        gdf = gdf.set_index("sources")
+        gdf = gdf.set_index("sid")
 
     return gdf
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -184,7 +184,7 @@ def st_create_grid(gdf, res):
 
     x, y = _grid_centroids(total_bounds, res)
     coords = _cartesian_prod(x, y)
-    geoms = _create_grid_geoms(coords, res)
+    geoms = _create_grid_geoms(coords, xres=res, yres=res)
     # convex hull / concave hull
     grid = gpd.GeoDataFrame(geometry=geoms, crs=gdf.crs)
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -1,4 +1,6 @@
+import warnings
 import numpy as np
+import dask.array as da
 import pandas as pd
 import geopandas as gpd
 
@@ -76,7 +78,14 @@ def _get_bbox(gdf):
     return (xmin, ymin, xmax, ymax)
 
 
-def rio2gdf(rioxarray_obj, method="points", mask=None, crs=None):
+def rio2gdf(
+    rioxarray_obj,
+    method="points",
+    mask=None,
+    crs=None,
+    name="pop",
+    dask=True,
+):
     """
     A function that convert a rioxarray object to a
     GeoPandas GeoDataFrame object
@@ -90,11 +99,11 @@ def rio2gdf(rioxarray_obj, method="points", mask=None, crs=None):
 
     # Get cell values and coords
     vals = _get_rio_vals(rioxarray_obj)
-    coords = _get_rio_coords(rioxarray_obj)
+    coords = _get_rio_coords(rioxarray_obj, dask)
 
     # Filter vals using mask
     if mask is not None:
-        vals, coords = _mask(vals, coords, mask)
+        vals, coords = _mask(vals, coords, mask, dask)
 
     methods = ["points", "polygons"]
 
@@ -105,11 +114,13 @@ def rio2gdf(rioxarray_obj, method="points", mask=None, crs=None):
     else:
         raise ValueError(f"Only '{methods}' are supported")
 
-    return gpd.GeoDataFrame(
-        pd.Series(vals.ravel(), name="Value"),
-        geometry=geoms,
-        crs=crs,
-    )
+    if dask:
+        df = pd.Series(vals.compute().ravel(), name=name)
+        geoms = geoms.compute()
+    else:
+        df = pd.Series(vals.ravel(), name=name)
+
+    return gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
 
 
 def _get_rio_vals(rioxarray_obj):
@@ -117,11 +128,11 @@ def _get_rio_vals(rioxarray_obj):
     return np.array(rioxarray_obj).reshape(-1, 1)
 
 
-def _get_rio_coords(rioxarray_obj):
+def _get_rio_coords(rioxarray_obj, dask):
     """Get rio corodinates"""
     x, y = _get_xy_coords(rioxarray_obj)
 
-    return _cartesian_prod(x, y)
+    return _cartesian_prod(x, y, dask)
 
 
 def _get_xy_coords(rioxarray_obj):
@@ -129,20 +140,32 @@ def _get_xy_coords(rioxarray_obj):
     return np.array(rioxarray_obj.x), np.array(rioxarray_obj.y)
 
 
-def _cartesian_prod(x, y):
+def _cartesian_prod(x, y, dask=True):
     """Calculate the cartesian product of x and y coords"""
 
-    mesh = np.meshgrid(x, y)
-    elem = mesh[0].size
-    concat = np.concatenate(mesh).ravel()
+    if dask:
+        x_dask = da.from_array(x, chunks=len(x) // 5)
+        y_dask = da.from_array(y, chunks=len(y) // 5)
 
-    return np.reshape(concat, (2, elem)).T
+        mesh = da.meshgrid(x_dask, y_dask)
+        elem = mesh[0].size
+        concat = da.concatenate(mesh).ravel()
+        return da.reshape(concat, (2, elem)).T
+
+    else:
+        mesh = np.meshgrid(x, y)
+        elem = mesh[0].size
+        concat = np.concatenate(mesh).ravel()
+        return np.reshape(concat, (2, elem)).T
 
 
-def _mask(vals, coords, mask):
+def _mask(vals, coords, mask, dask=True):
     """mask values and coords"""
 
-    ind = np.where(vals > mask)[0]
+    if dask:
+        ind = da.where(vals > mask)[0]
+    else:
+        ind = np.where(vals > mask)[0]
 
     return vals[ind], coords[ind]
 
@@ -177,18 +200,46 @@ def _create_grid_geoms(coords, xres, yres):
     return box(xmins, ymins, xmaxs, ymaxs)
 
 
-def st_make_grid(gdf, res):
-    """Assumes projected coords e.g. res in metres"""
+def st_make_grid(
+    gdf=None,
+    total_bounds=None,
+    res=100,
+    crs=None,
+    include_xy=True,
+    index=True,
+):
+    """
+    A function that creates grids (square) covering the bounding box of a GeoDataFrame
+    Assumes projected coords e.g. res in metres"""
 
-    total_bounds = gdf.total_bounds
+    import random
+    from fastuuid import UUID
+
+    if total_bounds is None:
+        total_bounds = gdf.total_bounds
 
     x, y = _grid_centroids(total_bounds, res)
     coords = _cartesian_prod(x, y)
     geoms = _create_grid_geoms(coords, xres=res, yres=res)
-    # convex hull / concave hull
-    grid = gpd.GeoDataFrame(geometry=geoms, crs=gdf.crs)
 
-    return grid
+    if crs:
+        print(f"Using the following crs: {crs} for gridded GeoDataFrame")
+    elif gdf is not None and crs is None:
+        crs = gdf.crs
+        warnings.warn("Using crs set in GeoDataFrame")
+    elif crs is None:
+        warnings.warn("No crs or GeoDataFrame passed, so no crs is set for the resultant GeoDataFrame")
+
+    if include_xy:
+        df = pd.DataFrame({"x": coords[:, 0], "y": coords[:, 1]})
+        gdf = gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
+    else:
+        gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
+
+    if index:
+        gdf["uuid"] = [UUID(int=random.getrandbits(128), version=4) for x in range(len(gdf))]
+
+    return gdf
 
 
 def _grid_centroids(total_bounds, res):

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -87,8 +87,27 @@ def rio2gdf(
     dask=True,
 ):
     """
-    A function that convert a rioxarray object to a
-    GeoPandas GeoDataFrame object
+    Transform raster to GeoDataFrame as points or polygons
+
+    Parameters
+    ----------
+    rioxarray_obj: rioxarray object
+
+    methods: str
+        whether to return points (mid points) or polygons
+    mask: int
+        what cell values to not include
+    crs: int
+        epsg code for coordinate reference system
+    name: str
+        column name for cell values
+    dask: bool
+        whether to use dask
+
+    Returns
+    -------
+    type: gpd.GeoDataFrame
+        GeoDataFrame containing cell geometries and values
     """
 
     if crs is None:

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -42,6 +42,7 @@ def _uid(df, uid=None, uid_type="sources"):
 def _create_uid(df, uid_type="sources"):
     """Creates a unique identifer"""
     import uuid
+
     if uid_type == "sources":
         uid = "sid"
     elif uid_type == "targets":
@@ -108,7 +109,7 @@ def rio2gdf(rioxarray_obj, method="points", mask=None, crs=None):
         pd.Series(vals.ravel(), name="Value"),
         geometry=geoms,
         crs=crs,
-        )
+    )
 
 
 def _get_rio_vals(rioxarray_obj):
@@ -155,11 +156,17 @@ def rio2points(coords):
 def rio2polygons(coords, rioxarray_obj):
     """A function that returns polygon geoms for a rioxarray object"""
 
-    from pygeos import box
-
     # Juggle around x, y values
     af = rioxarray_obj.rio.transform()
     xres, yres = abs(af[0]), abs(af[4])
+
+    return _create_grid_geoms(coords, xres, yres)
+
+
+def _create_grid_geoms(coords, xres, yres):
+
+    """Create polygon grids based on x,y coords and x and y resolution"""
+    from pygeos import box
 
     xmins = coords[:, 0] - (xres / 2)
     xmaxs = coords[:, 0] + (xres / 2)

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -209,9 +209,33 @@ def st_make_grid(
     index=True,
     dask=True,
 ):
+
     """
-    A function that creates grids (square) covering the bounding box of a GeoDataFrame
-    Assumes projected coords e.g. res in metres"""
+    Creates grids (square) covering the bounding box of a GeoDataFrame
+    Assumes projected coords e.g. res in metres
+
+    Parameters
+    ----------
+    gdf: gpd.GeoDataFrame (optional)
+        GeoDataFrame containing nation boundaries
+    total_bounds: list
+        total bounds of GeoDataFrame (optional)
+    res: int
+        cell resolution in m
+    crs: int
+        epsg code for coordinate reference system
+    include_xy: bool
+        whether to include x,y coords (mid point)
+    index: bool
+        whether to include a unique index
+    dask: bool
+        whether to use dask
+
+    Returns
+    -------
+    type: gpd.GeoDataFrame
+        GeoDataFrame containing cell geometries
+    """
 
     import random
     from fastuuid import UUID

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -237,9 +237,6 @@ def st_make_grid(
         GeoDataFrame containing cell geometries
     """
 
-    import random
-    from fastuuid import UUID
-
     if total_bounds is None:
         total_bounds = gdf.total_bounds
 
@@ -262,6 +259,8 @@ def st_make_grid(
         gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
 
     if index:
+        import random
+        from fastuuid import UUID
         gdf["uuid"] = [UUID(int=random.getrandbits(128), version=4) for x in range(len(gdf))]
 
     return gdf

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -155,7 +155,7 @@ def rio2gdf(
         if dask:
             coords = coords.compute()
             geoms = geoms.compute()
-        df = pd.DataFrame({"x": coords[:, 0], "y": coords[:, 1]})
+        df = pd.DataFrame({"x": coords[:, 0], "y": coords[:, 1], name: vals.ravel()})
         gdf = gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
     else:
         if dask:

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -96,6 +96,7 @@ def rio2gdf(
     name="pop",
     include_xy=True,
     index=True,
+    index_name="tid",
     dask=True,
 ):
     """
@@ -116,6 +117,8 @@ def rio2gdf(
         whether to include x,y coords (mid point)
     index: bool
         whether to include an index
+    index_name: str
+        name of index
     dask: bool
         whether to use dask
 
@@ -160,7 +163,7 @@ def rio2gdf(
         gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
 
     if index:
-        gdf, uid = _create_uid(gdf, uid_type="sources")
+        gdf, uid = create_uid(gdf, uid=index_name).set_index(index_name)
 
     return gdf
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -85,6 +85,7 @@ def rio2gdf(
     mask=None,
     crs=None,
     name="pop",
+    index=True,
     dask=True,
 ):
     """
@@ -102,6 +103,8 @@ def rio2gdf(
         epsg code for coordinate reference system
     name: str
         column name for cell values
+    index: bool
+        whether to include an index
     dask: bool
         whether to use dask
 
@@ -140,7 +143,12 @@ def rio2gdf(
     else:
         df = pd.Series(vals.ravel(), name=name)
 
-    return gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
+    gdf = gpd.GeoDataFrame(df, geometry=geoms, crs=crs)
+
+    if index:
+        gdf, uid = _create_uid(gdf, uid_type="sources")
+
+    return gdf
 
 
 def st_make_grid(
@@ -208,10 +216,7 @@ def st_make_grid(
         gdf = gpd.GeoDataFrame(geometry=geoms, crs=crs)
 
     if index:
-
-        gdf["uuid"] = [
-            UUID(int=random.getrandbits(128), version=4) for x in range(len(gdf))
-        ]
+        gdf, uid = _create_uid(gdf, uid_type="sources")
 
     return gdf
 

--- a/coss/utils.py
+++ b/coss/utils.py
@@ -207,6 +207,7 @@ def st_make_grid(
     crs=None,
     include_xy=True,
     index=True,
+    dask=True,
 ):
     """
     A function that creates grids (square) covering the bounding box of a GeoDataFrame
@@ -219,7 +220,7 @@ def st_make_grid(
         total_bounds = gdf.total_bounds
 
     x, y = _grid_centroids(total_bounds, res)
-    coords = _cartesian_prod(x, y)
+    coords = _cartesian_prod(x, y, dask)
     geoms = _create_grid_geoms(coords, xres=res, yres=res)
 
     if crs:


### PR DESCRIPTION
The [R package sf](https://r-spatial.github.io/sf/reference/st_make_grid.html) has a `st_make_grid`function for creating regular tessellations over a bounding box of an sf object.
Similarly, I have added some basic functionality from sf to create a grid based on the total bounds of a geopandas.GeoDataFrame.
This creates square grids based on the corner points of geometries and was quickly adapted based on some functionality already within coss.

